### PR TITLE
Add MIT License and update composer.json to specify license

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Inanc Haluk Aksoy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "aksoyih/random-profile",
     "description": "Generate random user profiles with detailed information, tailored for Turkish data",
     "type": "library",
+    "license": "MIT",
     "require": {
         "php": "^8.3",
         "fakerphp/faker": "^1.24",


### PR DESCRIPTION
This pull request includes the addition of a license file and an update to the `composer.json` file to include the license type.

License addition:

* [`LICENCE`](diffhunk://#diff-b4668a52683f65fbc0528f6590ba160c9c64c88c302b6262c506266eb1d35180R1-R21): Added the MIT License to the project.

Composer file update:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R5): Added the `license` field with the value "MIT".